### PR TITLE
Bounding Circle implementation

### DIFF
--- a/voronoi/algorithm.py
+++ b/voronoi/algorithm.py
@@ -5,11 +5,9 @@ from voronoi.graph import HalfEdge, Vertex, Algebra
 from voronoi.nodes import LeafNode, Arc, Breakpoint, InternalNode
 from voronoi.events import CircleEvent, SiteEvent
 from voronoi.tree import SmartTree, SmartNode
-from voronoi.visualization import Visualization
+from voronoi.visualization import vis
 from voronoi.visualization import Tell
 
-
-vis = Visualization()
 
 class Algorithm:
     def __init__(self, bounding_poly=None):
@@ -146,10 +144,10 @@ class Algorithm:
 
         # Final visualization
         if vis_result:
-            vis2 = Visualization()
-            vis2.visualize(-1000, current_event="Final result", bounding_poly=self.bounding_poly,
+            vis.visualize(-1000, current_event="Final result", bounding_poly=self.bounding_poly,
                       points=self.points, vertices=self.vertices, edges=self.edges, arc_list=self.arcs,
                       event_queue=self.event_queue, calc_cell_sizes=True)
+            vis.fig.show()
 
     def handle_site_event(self, event: SiteEvent, verbose=False):
 

--- a/voronoi/algorithm.py
+++ b/voronoi/algorithm.py
@@ -5,9 +5,11 @@ from voronoi.graph import HalfEdge, Vertex, Algebra
 from voronoi.nodes import LeafNode, Arc, Breakpoint, InternalNode
 from voronoi.events import CircleEvent, SiteEvent
 from voronoi.tree import SmartTree, SmartNode
-from voronoi.visualization import visualize
+from voronoi.visualization import Visualization
 from voronoi.visualization import Tell
 
+
+vis = Visualization()
 
 class Algorithm:
     def __init__(self, bounding_poly=None):
@@ -103,7 +105,7 @@ class Algorithm:
                     self.beach_line.visualize()
 
                 if vis_steps:
-                    visualize(self.sweep_line, current_event=event, bounding_poly=self.bounding_poly,
+                    vis.visualize(self.sweep_line, current_event=event, bounding_poly=self.bounding_poly,
                               points=self.points, vertices=self.vertices, edges=self.edges, arc_list=self.arcs,
                               event_queue=self.event_queue)
 
@@ -128,22 +130,24 @@ class Algorithm:
                     self.beach_line.visualize()
 
                 if vis_steps:
-                    visualize(y=self.sweep_line, current_event=event, bounding_poly=self.bounding_poly,
+                    vis.visualize(y=self.sweep_line, current_event=event, bounding_poly=self.bounding_poly,
                               points=self.points, vertices=self.vertices, edges=self.edges, arc_list=self.arcs,
                               event_queue=self.event_queue)
 
         if vis_before_clipping:
-            visualize(y=-1000, current_event="nothing", bounding_poly=self.bounding_poly,
+            vis.visualize(y=-1000, current_event="nothing", bounding_poly=self.bounding_poly,
                       points=self.points, vertices=self.vertices, edges=self.edges, arc_list=self.arcs,
                       event_queue=self.event_queue)
 
         # Finish with the bounding box
-        self.edges, polygon_vertices = self.bounding_poly.finish_edges(self.edges, verbose)
+        self.edges, polygon_vertices = self.bounding_poly.finish_edges(self.edges, verbose, self.vertices, self.points, self.event_queue, )
+#        self.edges, polygon_vertices = self.bounding_poly.finish_edges(self.edges, verbose)
         self.edges, self.vertices = self.bounding_poly.finish_polygon(self.edges, self.vertices, self.points)
 
         # Final visualization
         if vis_result:
-            visualize(-1000, current_event="Final result", bounding_poly=self.bounding_poly,
+            vis2 = Visualization()
+            vis2.visualize(-1000, current_event="Final result", bounding_poly=self.bounding_poly,
                       points=self.points, vertices=self.vertices, edges=self.edges, arc_list=self.arcs,
                       event_queue=self.event_queue, calc_cell_sizes=True)
 

--- a/voronoi/graph/bounding_circle.py
+++ b/voronoi/graph/bounding_circle.py
@@ -22,7 +22,7 @@ class BoundingCircle(Polygon):
     def inside(self, point):
         return (self.x - point.x)**2 + (self.y - point.y)**2 < self.radius**2
 
-    def finish_edges(self, edges, vertices, points, event_queue, verbose=False):
+    def finish_edges(self, edges, verbose=False, vertices=None, points=None, event_queue=None):
         resulting_edges = []
         for edge in edges:
             A = edge.get_origin()
@@ -35,9 +35,9 @@ class BoundingCircle(Polygon):
                 self.trim_edge(edge.twin)
 
             resulting_edges.append(edge)
-
-            visualize(y=-1000, current_event="nothing", bounding_poly=self,
-                      points=points, vertices=vertices + self.polygon_vertices, edges=edges, arc_list=[], event_queue=event_queue)
+            if vertices and points and event_queue:
+                visualize(y=-1000, current_event="nothing", bounding_poly=self,
+                          points=points, vertices=vertices + self.polygon_vertices, edges=edges, arc_list=[], event_queue=event_queue)
 
         # Re-order polygon vertices
         self.polygon_vertices = self.get_ordered_vertices(self.polygon_vertices)

--- a/voronoi/graph/bounding_circle.py
+++ b/voronoi/graph/bounding_circle.py
@@ -1,0 +1,116 @@
+from math import sqrt
+
+from voronoi import Polygon, Point, Coordinate
+from voronoi.graph import Vertex
+import numpy as np
+from voronoi.visualization import visualize
+
+
+class BoundingCircle(Polygon):
+
+    def __init__(self, x, y, radius):
+        self.x = x
+        self.y = y
+        self.radius = radius
+        self.polygon_vertices = []
+        self.center = Coordinate(self.x, self.y)
+        self.max_x = self.x + self.radius
+        self.min_x = self.x - self.radius
+        self.max_y = self.y + self.radius
+        self.min_y = self.y - self.radius
+
+    def inside(self, point):
+        return (self.x - point.x)**2 + (self.y - point.y)**2 < self.radius**2
+
+    def finish_edges(self, edges, vertices, points, event_queue, verbose=False):
+        resulting_edges = []
+        for edge in edges:
+            A = edge.get_origin()
+            B = edge.twin.get_origin()
+
+            if A is None or not self.inside(A):
+                self.trim_edge(edge)
+
+            if B is None or not self.inside(B):
+                self.trim_edge(edge.twin)
+
+            resulting_edges.append(edge)
+
+            visualize(y=-1000, current_event="nothing", bounding_poly=self,
+                      points=points, vertices=vertices + self.polygon_vertices, edges=edges, arc_list=[], event_queue=event_queue)
+
+        # Re-order polygon vertices
+        self.polygon_vertices = self.get_ordered_vertices(self.polygon_vertices)
+
+        return resulting_edges, self.polygon_vertices
+
+
+    def trim_edge(self, edge, twisted=False):
+        if edge.get_origin() is None or edge.twin.get_origin() is None:
+            point = self.cut_ray(edge, twisted)
+        else:
+            point = self.cut_line(edge)
+
+        # Create vertex
+        v = Vertex(point=point)
+        v.incident_edges.append(edge)
+        edge.origin = v
+        self.polygon_vertices.append(v)
+
+        return edge
+
+    def get_ray(self, edge):
+        A = edge.origin.breakpoint[0]
+        B = edge.origin.breakpoint[1]
+        center = Point(x=(A.x+B.x)/2., y=(A.y+B.y)/2.)
+
+        if edge.twin.get_origin() is None:
+            ray_start = center
+        else:
+            ray_start = edge.twin.origin.point
+        a = (B.x - A.x) / (B.y - A.y)
+        c = center.x * a + center.y
+        return ray_start, center, a, c
+
+    def cut_line(self, edge):
+        A = edge.get_origin()
+        B = edge.twin.get_origin()
+        a = - (B.y - A.y) / (B.x - A.x)
+        c = (A.y * B.x - B.y * A.x) / (B.x - A.x)
+        point1, point2 = self.cut(a,c)
+        dx = (A.x - B.x)
+        dy = (A.y - B.y)
+        dpx = (A.x - point1.x)
+        dpy = (A.y - point1.y)
+        if abs((dpx * dx + dpy * dy)/sqrt(dx**2 + dy**2)/sqrt(dpx**2 + dpy**2)-1.) < 1e-5 :
+            return point1
+        else:
+            return point2
+
+    def cut_ray(self, edge, twisted=False):
+        A, B, a, c = self.get_ray(edge)
+        point1, point2 = self.cut(a,c)
+
+        dx = (edge.origin.breakpoint[0].x - edge.origin.breakpoint[1].x)
+        dy = (edge.origin.breakpoint[0].y - edge.origin.breakpoint[1].y)
+        dpx = (edge.origin.breakpoint[0].x - point1.x)
+        dpy = (edge.origin.breakpoint[0].y - point1.y)
+        if dx * dpy - dy * dpx < 0:
+            return point1
+        else:
+            return point2
+
+    def cut(self, a, c):
+        b = 1
+        d = c - a * self.x - b * self.y
+        a_sq_b_sq = a**2 + b**2
+        big_sqrt = sqrt(self.radius**2 * a_sq_b_sq - d**2).real
+
+        x1 = self.x + (a * d + b * big_sqrt)/a_sq_b_sq
+        y1 = self.y + (b * d - a * big_sqrt)/a_sq_b_sq
+        point1 = Point(x=x1, y=y1)
+        x2 = self.x + (a * d - b * big_sqrt)/a_sq_b_sq
+        y2 = self.y + (b * d + a * big_sqrt)/a_sq_b_sq
+        point2 = Point(x=x2, y=y2)
+
+        return point1, point2

--- a/voronoi/graph/coordinate.py
+++ b/voronoi/graph/coordinate.py
@@ -10,3 +10,6 @@ class Coordinate:
 
     def __repr__(self):
         return f"({round(self.x, 3)}, {round(self.y, 3)})"
+
+    def __sub__(self, other):
+        return Coordinate(x=self.x-other.x, y=self.y-other.y)

--- a/voronoi/graph/half_edge.py
+++ b/voronoi/graph/half_edge.py
@@ -17,15 +17,17 @@ class HalfEdge:
         # Next and previous
         self.next = None
         self.prev = None
+        self.index = 0
 
         self.removed = False
 
     def __repr__(self):
-        return f"HalfEdge({self.incident_point})"
+        return f"{self.incident_point}_{self.index}"
 
     def set_next(self, next):
         if next:
             next.prev = self
+            next.index = self.index + 1
         self.next = next
 
     def get_origin(self, y=None, max_y=None):

--- a/voronoi/graph/point.py
+++ b/voronoi/graph/point.py
@@ -66,6 +66,9 @@ class Point(Coordinate):
         y = [coordinate.y for coordinate in coordinates]
         return x, y
 
+    def __sub__(self, other):
+        return Point(x=self.x-other.x, y=self.y-other.y)
+
     @staticmethod
     def _shoelace(x, y):
         return 0.5 * np.abs(np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1)))

--- a/voronoi/tests/example_circle.py
+++ b/voronoi/tests/example_circle.py
@@ -5,8 +5,8 @@ from voronoi.graph.bounding_circle import BoundingCircle
 points = [
     (1, 2),
     (7, 13),
-#    (12, 6),
-#    (5, 5),
+    (12, 6),
+    (5, 5),
 ]
 
 # Define a bounding circle

--- a/voronoi/tests/example_circle.py
+++ b/voronoi/tests/example_circle.py
@@ -5,16 +5,16 @@ from voronoi.graph.bounding_circle import BoundingCircle
 points = [
     (1, 2),
     (7, 13),
-    (12, 6),
-    (5, 5),
+#    (12, 6),
+#    (5, 5),
 ]
 
 # Define a bounding circle
-bounding_circle = BoundingCircle(5., 5., 15.)
+bounding_circle = BoundingCircle(5., 5., 9.)
 
 v = Voronoi(bounding_circle)
 
-v.create_diagram(points=points, vis_before_clipping=True, vis_steps=False, verbose=False, vis_result=True, vis_tree=True)
+v.create_diagram(points=points, vis_before_clipping=True, vis_steps=True, verbose=True, vis_result=True, vis_tree=True)
 
 edges = v.edges
 vertices = v.vertices

--- a/voronoi/tests/example_circle.py
+++ b/voronoi/tests/example_circle.py
@@ -1,0 +1,22 @@
+from voronoi import Voronoi
+from voronoi.graph.bounding_circle import BoundingCircle
+
+# Define a set of points
+points = [
+    (1, 2),
+    (7, 13),
+    (12, 6),
+    (5, 5),
+]
+
+# Define a bounding circle
+bounding_circle = BoundingCircle(5., 5., 15.)
+
+v = Voronoi(bounding_circle)
+
+v.create_diagram(points=points, vis_before_clipping=True, vis_steps=False, verbose=False, vis_result=True, vis_tree=True)
+
+edges = v.edges
+vertices = v.vertices
+arcs = v.arcs
+points = v.points

--- a/voronoi/tests/line.py
+++ b/voronoi/tests/line.py
@@ -1,0 +1,24 @@
+from voronoi import Point
+from voronoi.graph.bounding_circle import BoundingCircle
+
+
+bc = BoundingCircle(5,6,12)
+
+p1 = Point(1,2)
+p2 = Point(7.5, 21.4)
+a = bc.get_line(p1, p2)
+print(a)
+
+p1 = Point(1,2)
+p2 = Point(7.5, 2)
+a = bc.get_line(p1, p2)
+print(a)
+
+p1 = Point(1,2)
+p2 = Point(1, 11.2)
+a = bc.get_line(p1, p2)
+print(a)
+
+
+
+pass

--- a/voronoi/visualization/__init__.py
+++ b/voronoi/visualization/__init__.py
@@ -1,2 +1,2 @@
 from voronoi.visualization.tell import Tell
-from voronoi.visualization.visual import visualize
+from voronoi.visualization.visual import Visualization

--- a/voronoi/visualization/__init__.py
+++ b/voronoi/visualization/__init__.py
@@ -1,2 +1,4 @@
 from voronoi.visualization.tell import Tell
 from voronoi.visualization.visual import Visualization
+
+vis = Visualization()

--- a/voronoi/visualization/visual.py
+++ b/voronoi/visualization/visual.py
@@ -24,11 +24,14 @@ class Visualization(object):
 
     def __init__(self):
         self.init()
+        plt.show()
 
     def init(self):
-        self.fig, self.ax = plt.subplots(figsize=(7, 7))
+        self.fig, self.ax = plt.subplots(figsize=(17, 17))
 
     def visualize(self, y, current_event, bounding_poly, points, vertices, edges, arc_list, event_queue, calc_cell_sizes=True):
+        plt.close()
+        self.init()
         self.ax.set_title( str(current_event) )
         scale = (bounding_poly.max_y - bounding_poly.min_y)
         border = (bounding_poly.max_y - bounding_poly.min_y) / 4
@@ -76,6 +79,12 @@ class Visualization(object):
             # Draw line
             if start and end:
                 self.ax.plot([start.x, end.x], [start.y, end.y], Colors.EDGE)
+                # Add Name
+                plt.annotate(
+                        text=str(edge),
+                        xy=((end.x+start.x)/2, (end.y+start.y)/2)
+                )
+
 
             # Add arrow
             if start and end and start.y < float('inf'):
@@ -119,13 +128,11 @@ class Visualization(object):
             x, y = point.x, point.y
             self.ax.scatter(x=[x], y=[y], s=50, color=Colors.CELL_POINTS)
 
-            if calc_cell_sizes:
-                size = f"{point.cell_size(digits=2)}"
-                # plt.annotate(s=size, xy=(x, y), xytext=(100, y), arrowprops=dict(arrowstyle='->', facecolor="white"))
-                self.ax.text(s=size, x=x + scale / 100, y=y + scale / 100, color=Colors.TEXT)
-
+#            if calc_cell_sizes:
+#                size = f"{point.cell_size(digits=2)}"
+#               # plt.annotate(s=size, xy=(x, y), xytext=(100, y), arrowprops=dict(arrowstyle='->', facecolor="white"))
+#                self.ax.text(s=size, x=x + scale / 100, y=y + scale / 100, color=Colors.TEXT)
         self.fig.show()
-
 
     def plot_helper_points(self, A, B, center, start_ray, a, b, c):
         self.ax.scatter(x=[A.x, B.x, center.x, start_ray.x], y=[A.y, B.y, center.y, start_ray.y], s=50, color=Colors.HELPER)

--- a/voronoi/visualization/visual.py
+++ b/voronoi/visualization/visual.py
@@ -17,103 +17,151 @@ class Colors:
     TRIANGLE = "#00cec9"  # orange
     BOUNDING_BOX = "black"  # blue
     TEXT = "#00cec9"  # green
+    HELPER = "#ff0000"
+    HIGH_LIGHT = "#00ff00"
 
+class Visualization(object):
 
-def visualize(y, current_event, bounding_poly, points, vertices, edges, arc_list, event_queue, calc_cell_sizes=True):
-    fig, ax = plt.subplots(figsize=(7, 7))
-    plt.title(str(current_event))
-    scale = (bounding_poly.max_y - bounding_poly.min_y)
-    border = (bounding_poly.max_y - bounding_poly.min_y) / 4
-    plt.ylim((bounding_poly.min_y - border, bounding_poly.max_y + border))
-    plt.xlim((bounding_poly.min_x - border, bounding_poly.max_x + border))
+    def __init__(self):
+        self.init()
 
-    # Create 1000 equally spaced points between -10 and 10 and setup plot window
-    x = np.linspace(bounding_poly.min_x, bounding_poly.max_x, 1000)
-    x_full = np.linspace(bounding_poly.min_x - border, bounding_poly.max_x + border, 1000)
+    def init(self):
+        self.fig, self.ax = plt.subplots(figsize=(7, 7))
 
-    # Plot the sweep line
-    ax.plot([bounding_poly.min_x - border, bounding_poly.max_x + border], [y, y], color=Colors.SWEEP_LINE)
+    def visualize(self, y, current_event, bounding_poly, points, vertices, edges, arc_list, event_queue, calc_cell_sizes=True):
+        self.ax.set_title( str(current_event) )
+        scale = (bounding_poly.max_y - bounding_poly.min_y)
+        border = (bounding_poly.max_y - bounding_poly.min_y) / 4
+        plt.ylim((bounding_poly.min_y - border, bounding_poly.max_y + border))
+        plt.xlim((bounding_poly.min_x - border, bounding_poly.max_x + border))
 
-    # Plot all arcs
-    plot_lines = []
-    for arc in arc_list:
-        plot_line = arc.get_plot(x_full, y)
-        if plot_line is None:
-            ax.axvline(x=arc.origin.x)
+        # Create 1000 equally spaced points between -10 and 10 and setup plot window
+        x = np.linspace(bounding_poly.min_x, bounding_poly.max_x, 1000)
+        x_full = np.linspace(bounding_poly.min_x - border, bounding_poly.max_x + border, 1000)
+
+        # Plot the sweep line
+        self.ax.plot([bounding_poly.min_x - border, bounding_poly.max_x + border], [y, y], color=Colors.SWEEP_LINE)
+
+        # Plot all arcs
+        plot_lines = []
+        for arc in arc_list:
+            plot_line = arc.get_plot(x_full, y)
+            if plot_line is None:
+                self.ax.axvline(x=arc.origin.x)
+            else:
+                self.ax.plot(x_full, plot_line, linestyle="--", color=Colors.ARC)
+                plot_lines.append(plot_line)
+        if len(plot_lines) > 0:
+            self.ax.plot(x_full, np.min(plot_lines, axis=0), color=Colors.BEACH_LINE)
+
+        # Plot circle events
+        def plot_circle(evt):
+            x, y = evt.center.x, evt.center.y
+            radius = evt.radius
+            color = Colors.VALID_CIRCLE if evt.is_valid else Colors.INVALID_CIRCLE
+
+            # if evt.is_valid:
+            circle = plt.Circle((x, y), radius, fill=False, color=color, linewidth=1.2)
+            triangle = plt.Polygon(evt.get_triangle(), fill=False, color=Colors.TRIANGLE, linewidth=1.2)
+            self.ax.add_artist(circle)
+            self.ax.add_artist(triangle)
+
+        # Plot half-edges
+        for edge in edges:
+
+            # Get start and end of edges
+            start = edge.get_origin(y, bounding_poly.max_y)
+            end = edge.twin.get_origin(y, bounding_poly.max_y)
+
+            # Draw line
+            if start and end:
+                self.ax.plot([start.x, end.x], [start.y, end.y], Colors.EDGE)
+
+            # Add arrow
+            if start and end and start.y < float('inf'):
+                plt.annotate(s='', xy=(end.x, end.y), xytext=(start.x, start.y), arrowprops=dict(arrowstyle='->'))
+
+            # Point to incident point
+            incident_point = edge.incident_point
+            if start and end and incident_point:
+                self.ax.plot(
+                    [(start.x + end.x) / 2, incident_point.x], [(start.y + end.y) / 2, incident_point.y],
+                    color=Colors.INCIDENT_POINT_POINTER,
+                    linestyle="--"
+                )
+
+        if isinstance(current_event, CircleEvent):
+            plot_circle(current_event)
+
+        for event in event_queue.queue:
+            if isinstance(event, CircleEvent):
+                plot_circle(event)
+
+        if hasattr(bounding_poly, 'radius') :
+            # Draw bounding box
+            self.ax.add_patch(
+                    patches.Circle((bounding_poly.x, bounding_poly.x), bounding_poly.radius, fill=False,
+                            edgecolor=Colors.BOUNDING_BOX)
+            )
         else:
-            ax.plot(x_full, plot_line, linestyle="--", color=Colors.ARC)
-            plot_lines.append(plot_line)
-    if len(plot_lines) > 0:
-        ax.plot(x_full, np.min(plot_lines, axis=0), color=Colors.BEACH_LINE)
+            # Draw bounding box
+            self.ax.add_patch(
+                patches.Polygon(bounding_poly.get_coordinates(), fill=False, edgecolor=Colors.BOUNDING_BOX)
+            )
 
-    # Plot circle events
-    def plot_circle(evt):
-        x, y = evt.center.x, evt.center.y
-        radius = evt.radius
-        color = Colors.VALID_CIRCLE if evt.is_valid else Colors.INVALID_CIRCLE
+        # Plot vertices
+        for vertex in vertices:
+            x, y = vertex.position.x, vertex.position.y
+            self.ax.scatter(x=[x], y=[y], s=50, color=Colors.VERTICES)
 
-        # if evt.is_valid:
-        circle = plt.Circle((x, y), radius, fill=False, color=color, linewidth=1.2)
-        triangle = plt.Polygon(evt.get_triangle(), fill=False, color=Colors.TRIANGLE, linewidth=1.2)
-        ax.add_artist(circle)
-        ax.add_artist(triangle)
+        # Plot points
+        for point in points:
+            x, y = point.x, point.y
+            self.ax.scatter(x=[x], y=[y], s=50, color=Colors.CELL_POINTS)
 
-    # Plot half-edges
-    for edge in edges:
+            if calc_cell_sizes:
+                size = f"{point.cell_size(digits=2)}"
+                # plt.annotate(s=size, xy=(x, y), xytext=(100, y), arrowprops=dict(arrowstyle='->', facecolor="white"))
+                self.ax.text(s=size, x=x + scale / 100, y=y + scale / 100, color=Colors.TEXT)
 
+        self.fig.show()
+
+
+    def plot_helper_points(self, A, B, center, start_ray, a, b, c):
+        self.ax.scatter(x=[A.x, B.x, center.x, start_ray.x], y=[A.y, B.y, center.y, start_ray.y], s=50, color=Colors.HELPER)
+        self.ax.plot(
+            [start_ray.x , center.x], [start_ray.y, (c - a* center.x)/b],
+                    color=Colors.HELPER
+                )
+        self.fig.show()
+
+    def plot_points(self, A, B):
+        self.ax.scatter(x=[A.x, B.x], y=[A.y, B.y], s=50, color=Colors.HELPER)
+        self.fig.show()
+
+
+    def highlight_edge(self, y, bounding_poly, edge):
         # Get start and end of edges
         start = edge.get_origin(y, bounding_poly.max_y)
         end = edge.twin.get_origin(y, bounding_poly.max_y)
 
         # Draw line
         if start and end:
-            plt.plot([start.x, end.x], [start.y, end.y], Colors.EDGE)
+            self.ax.plot([start.x, end.x], [start.y, end.y], Colors.HIGH_LIGHT, linewidth=5)
 
         # Add arrow
         if start and end and start.y < float('inf'):
-            plt.annotate(s='', xy=(end.x, end.y), xytext=(start.x, start.y), arrowprops=dict(arrowstyle='->'))
-
-        # Point to incident point
-        incident_point = edge.incident_point
-        if start and end and incident_point:
-            plt.plot(
-                [(start.x + end.x) / 2, incident_point.x], [(start.y + end.y) / 2, incident_point.y],
-                color=Colors.INCIDENT_POINT_POINTER,
-                linestyle="--"
+            self.ax.annotate(
+                    s='',
+                    xy=(end.x, end.y),
+                    xytext=(start.x, start.y),
+                    arrowprops=dict(
+                            arrowstyle='->',
+                            linewidth=5,
+                            color=Colors.HIGH_LIGHT
+                    )
             )
 
-    if isinstance(current_event, CircleEvent):
-        plot_circle(current_event)
+        self.fig.show()
 
-    for event in event_queue.queue:
-        if isinstance(event, CircleEvent):
-            plot_circle(event)
 
-    if hasattr(bounding_poly, 'radius') :
-        # Draw bounding box
-        ax.add_patch(
-                patches.Circle((bounding_poly.x, bounding_poly.x), bounding_poly.radius, fill=False,
-                        edgecolor=Colors.BOUNDING_BOX)
-        )
-    else:
-        # Draw bounding box
-        ax.add_patch(
-            patches.Polygon(bounding_poly.get_coordinates(), fill=False, edgecolor=Colors.BOUNDING_BOX)
-        )
-
-    # Plot vertices
-    for vertex in vertices:
-        x, y = vertex.position.x, vertex.position.y
-        ax.scatter(x=[x], y=[y], s=50, color=Colors.VERTICES)
-
-    # Plot points
-    for point in points:
-        x, y = point.x, point.y
-        ax.scatter(x=[x], y=[y], s=50, color=Colors.CELL_POINTS)
-
-        if calc_cell_sizes:
-            size = f"{point.cell_size(digits=2)}"
-            # plt.annotate(s=size, xy=(x, y), xytext=(100, y), arrowprops=dict(arrowstyle='->', facecolor="white"))
-            plt.text(s=size, x=x + scale / 100, y=y + scale / 100, color=Colors.TEXT)
-
-    plt.show()

--- a/voronoi/visualization/visual.py
+++ b/voronoi/visualization/visual.py
@@ -89,10 +89,17 @@ def visualize(y, current_event, bounding_poly, points, vertices, edges, arc_list
         if isinstance(event, CircleEvent):
             plot_circle(event)
 
-    # Draw bounding box
-    ax.add_patch(
-        patches.Polygon(bounding_poly.get_coordinates(), fill=False, edgecolor=Colors.BOUNDING_BOX)
-    )
+    if hasattr(bounding_poly, 'radius') :
+        # Draw bounding box
+        ax.add_patch(
+                patches.Circle((bounding_poly.x, bounding_poly.x), bounding_poly.radius, fill=False,
+                        edgecolor=Colors.BOUNDING_BOX)
+        )
+    else:
+        # Draw bounding box
+        ax.add_patch(
+            patches.Polygon(bounding_poly.get_coordinates(), fill=False, edgecolor=Colors.BOUNDING_BOX)
+        )
 
     # Plot vertices
     for vertex in vertices:


### PR DESCRIPTION
Dear Yatoom!

Thank you very much for this cool implementation of Fortune's algorithm.

My goal is to implement Voronoi diagrams for discs in Python. For the initialization of the disc algorithm I need a voronoi diagram clipped by a circle as a seed.

Your implementation of a bounding polygon for Voronoi diagrams aims in the same direction. So I decided to extend your code by a circular bounding box.

My code is cumbersome and no more than a most minimal experimental patch at the moment. This is just a prove of concept.

There are two critical points ATM.
1) Your code does has never thought of another type of bounding box.
2) Your great visualization code has some requirements closely related to some algorithm variables, so ATM a bounding_circle object cannot use them. 

But these are minor obstacles that can easily be solved as my pull request shows. 
Looking forward to read from you.

Cheers,
Volker

